### PR TITLE
Updates instantiate_all_loggers to take a path parameter

### DIFF
--- a/lib/bunyan_capybara.rb
+++ b/lib/bunyan_capybara.rb
@@ -24,16 +24,19 @@ module Bunyan
   # we run any of the examples.
   #
   # @note Call this method no more than once per spec
-  def self.instantiate_all_loggers!(config: ENV)
+  def self.instantiate_all_loggers!(config: ENV, path:)
     raise "You already called instantiate_all_loggers!" if @called
     @called = true
     layout = Logging.layouts.pattern(format_as: :json, date_pattern: "%Y-%m-%d %H:%M:%S.%L")
     Logging.appenders.stdout(layout: layout)
-    entries = Dir.glob(File.expand_path('~/git/QA_tests/spec/*', __FILE__))
+    if !File.exist?(File.expand_path('~/bunyan_logs'))
+      Dir.mkdir(File.expand_path('~/bunyan_logs'))
+    end
+    entries = Dir.glob(File.expand_path(path + '/*', __FILE__))
     entries.each do |entry|
       application_name_under_test = entry.split('/').last
       logger = Logging.logger[application_name_under_test]
-      log_filename = File.expand_path("~/git/QA_tests/logs/#{application_name_under_test}.log", __FILE__)
+      log_filename = File.expand_path("~/bunyan_logs/#{application_name_under_test}.log", __FILE__)
       logger.add_appenders('stdout', Logging.appenders.file(log_filename, layout: layout))
       logger.level = config.fetch('LOG_LEVEL', DEFAULT_LOG_LEVEL).to_sym
     end
@@ -221,6 +224,7 @@ module Bunyan
       end
 
       def initialize_example_variables!
+        require 'byebug'; debugger
         @example_variable = BunyanVariableExtractor.call(path: @example.metadata.fetch(:absolute_file_path), config: config)
       end
   end


### PR DESCRIPTION
In order for the gem to work for others with different file/folder folder structures, the instantiate_all_loggers method must
use the __FILE__ path to find where the test/spec/tests folder for that structure.  This way, the gem can correctly find the names for the
specs and create appropriate .log files.  This is the purpose of the path parameter.  In addition, as folder structure very in depth, the
gem now looks if a ~/bunyan_logs folder exists and if it doesnt it creates the folder, this helps prevent any other errors in regard to the
existence of a logs folder.  This bunyan_logs folder will be were the .log files will be kept for future use.